### PR TITLE
feat: add postgres service to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  postgres:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_USER: 74ccdd
+      POSTGRES_PASSWORD: 74ccdd
+      POSTGRES_DB: 74ccdd
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:


### PR DESCRIPTION
Add a Postgres 16 service with persistent volume and environment
variables for user, password, and database. Enable automatic restart
and expose port 5432 for local development and testing.